### PR TITLE
Add fix for header menu conflict between showcase and datarequest

### DIFF
--- a/ckanext/tayside/templates/header.html
+++ b/ckanext/tayside/templates/header.html
@@ -1,0 +1,12 @@
+{% ckan_extends %}
+
+{% block header_site_navigation_tabs %}
+  {{ h.build_nav_main(
+    ('search', _('Datasets')),
+    ('organizations_index', _('Organizations')),
+    ('group_index', _('Groups')),
+    ('ckanext_showcase_index', _('Showcases')),
+    ('datarequests_index', _('Data Requests') + h.get_open_datarequests_badge()),
+    ('about', _('About'))
+  ) }}
+{% endblock %}


### PR DESCRIPTION
Depending of the plugins order in the CKAN configuration file one extension is overwritten and hidden from the menu