### PR TITLE
Cache pip packages on Travis to save time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 python:
     - "2.7"
 env: PGVERSION=9.2
+cache: pip
 install:
     - bash bin/travis-build.bash
     - pip install coveralls


### PR DESCRIPTION
This PR will lower the time on the Travis build, because it will cache the Python packages on newer builds.