### PR TITLE
[fix][s]: Split tag_string into separate tags - Fixes #8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: python
 sudo: required
+
+# use an older trusty image, because the newer images cause build errors with
+# psycopg2 that comes with CKAN<2.8:
+#   "Error: could not determine PostgreSQL version from '10.1'"
+# see https://github.com/travis-ci/travis-ci/issues/8897
+dist: trusty
+group: deprecated-2017Q4
+
 python:
     - "2.7"
 services:

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -14,8 +14,8 @@ git checkout ckan-2.7.0
 python setup.py develop
 # Travis has an issue with older version of psycopg2 (2.4.5)
 sed -i 's/psycopg2==2.4.5/psycopg2==2.7.3.2/' requirements.txt
-pip install -r requirements.txt --allow-all-external
-pip install -r dev-requirements.txt --allow-all-external
+pip install -r requirements.txt
+pip install -r dev-requirements.txt
 cd -
 
 echo "Creating the PostgreSQL user and database..."

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -x
 
 echo "This is travis-build.bash..."
 
@@ -21,6 +22,14 @@ cd -
 echo "Creating the PostgreSQL user and database..."
 sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"
 sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan_default;'
+
+echo "Setting up Solr..."
+# Solr is multicore for tests on ckan master, but it's easier to run tests on
+# Travis single-core. See https://github.com/ckan/ckan/issues/2972
+sed -i -e 's/solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' ckan/test-core.ini
+printf "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
+sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
+sudo service jetty restart
 
 echo "Initialising the database..."
 cd ckan

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8987\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
+echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
 sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
 sudo service jetty restart
 

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
+echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8987\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
 sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
 sudo service jetty restart
 

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -1,10 +1,5 @@
 #!/bin/sh -e
 
-echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8987\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
-sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
-sudo service jetty restart
-
-
 nosetests --ckan \
           --nologcapture \
           --with-pylons=test.travis.ini \

--- a/ckanext/tayside/controllers/package.py
+++ b/ckanext/tayside/controllers/package.py
@@ -34,19 +34,18 @@ parse_params = logic.parse_params
 class PackageController(_PackageController):
 
     def _tag_string_to_list(self, tag_string):
-        ''' This method is overriden because "tag_string" that is sent through
+        ''' This method is overridden because "tag_string" that is sent through
         the form comes as an array and not as a string. In the original
         implementation this method expects a string. '''
 
         if isinstance(tag_string, unicode):
-            tag_string = [tag_string]
+            tags = tag_string.split(',')
 
         out = []
-        for tag in tag_string:
-            tag = tag.strip()
-            if tag:
-                out.append({'name': tag,
-                            'state': 'active'})
+
+        for tag in tags:
+            out.append({'name': tag, 'state': 'active'})
+
         return out
 
     def create_metadata_package(self):

--- a/test.travis.ini
+++ b/test.travis.ini
@@ -12,7 +12,7 @@ port = 5000
 use = config:ckan/test-core.ini
 
 ckan.site_url = http://localhost:5000
-solr_url = http://127.0.0.1:8987/solr
+solr_url = http://127.0.0.1:8983/solr
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
I have run into the same issue that #8 mentions. I'm seeing multiple tags concatenated (only for private datasets, not sure why on that). Looking at the function that's supposed to be separating them, it appears to only do the equivalent of this:

```
def _tag_string_to_list(self, tag_string):
    return [{'name': tag_string, 'state': 'active'}]
```